### PR TITLE
Fix RPATH issue in hailortcli build

### DIFF
--- a/hailort/hailortcli/CMakeLists.txt
+++ b/hailort/hailortcli/CMakeLists.txt
@@ -65,7 +65,9 @@ add_executable(hailortcli
 
 target_compile_options(hailortcli PRIVATE ${HAILORT_COMPILE_OPTIONS})
 set_property(TARGET hailortcli PROPERTY CXX_STANDARD 14)
-set_property(TARGET hailortcli PROPERTY INSTALL_RPATH "$ORIGIN" "../lib/") # Link with a relative libhailort
+set_property(TARGET hailortcli PROPERTY INSTALL_RPATH "\$ORIGIN/../lib/") # Link with a relative libhailort
+set_property(TARGET hailortcli PROPERTY BUILD_WITH_INSTALL_RPATH true) # Link with a relative libhailort
+
 target_link_libraries(hailortcli
     libhailort
     CLI11::CLI11


### PR DESCRIPTION
Currently, the RPATH is being set to `$ORIGIN:../lib` which is probably not is intended. This changes it to `$ORIGIN/../lib`
Also this sets the install RPATH at build time.